### PR TITLE
feat: add day-before reminder flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,4 @@ When adding tests, prefer:
 - Use Conventional Commits (`feat:`, `fix:`, `chore:`, etc.).
 - Commit in logical chunks (feature, refactor, config, docs).
 - Keep PRs focused; include what changed, why, and how it was validated.
+- PR description should include `Resolves #<issue number>` for linked issue closure.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Worker service that monitors Trumf's Trippel-Trumf page, extracts the next campa
 3. It extracts date candidates from article text using Norwegian month names.
 4. It stores the latest result and metadata in memory.
 5. It publishes state changes to a channel that the notifying worker forwards to Slack.
-6. It schedules the next check at UTC midnight and repeats.
+6. It evaluates day-before reminders in `Europe/Oslo` time and keeps reminder state in memory for the current process lifetime.
+7. It schedules the next check at UTC midnight and repeats.
 
 Slack payload shape:
 
@@ -36,6 +37,7 @@ src/melanki.trippeltrumf.service
 │   ├── Notifying/
 │   │   ├── Client.cs
 │   │   ├── Options.cs
+│   │   ├── Reminder.cs
 │   │   └── Worker.cs
 │   ├── Polling/
 │   │   ├── ChangeFeed.cs

--- a/melanki.trippeltrumf.sln
+++ b/melanki.trippeltrumf.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "melanki.trippeltrumf.service", "src\melanki.trippeltrumf.service\melanki.trippeltrumf.service.csproj", "{476DFCF8-C2B4-4D36-99B3-C659CC2524D8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "melanki.trippeltrumf.service.tests", "tests\melanki.trippeltrumf.service.tests\melanki.trippeltrumf.service.tests.csproj", "{3493210E-AACE-4602-A69E-A17150C531F2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,11 +33,24 @@ Global
 		{476DFCF8-C2B4-4D36-99B3-C659CC2524D8}.Release|x64.Build.0 = Release|Any CPU
 		{476DFCF8-C2B4-4D36-99B3-C659CC2524D8}.Release|x86.ActiveCfg = Release|Any CPU
 		{476DFCF8-C2B4-4D36-99B3-C659CC2524D8}.Release|x86.Build.0 = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|x64.Build.0 = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Debug|x86.Build.0 = Debug|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|x64.ActiveCfg = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|x64.Build.0 = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|x86.ActiveCfg = Release|Any CPU
+		{3493210E-AACE-4602-A69E-A17150C531F2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{476DFCF8-C2B4-4D36-99B3-C659CC2524D8} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{3493210E-AACE-4602-A69E-A17150C531F2} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/melanki.trippeltrumf.slnx
+++ b/melanki.trippeltrumf.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="src/melanki.trippeltrumf.service/melanki.trippeltrumf.service.csproj" />
+  <Project Path="tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj" />
 </Solution>

--- a/src/melanki.trippeltrumf.service/Composition/ServiceCollectionExtensions.cs
+++ b/src/melanki.trippeltrumf.service/Composition/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<Scraper>();
         services.AddSingleton<Polling.StateStore>();
         services.AddSingleton<Polling.ChangeFeed>();
+        services.AddSingleton<Notifying.ReminderStateStore>();
         services.AddHttpClient<Notifying.Client>();
         services.AddHostedService<Polling.Worker>();
         services.AddHostedService<Notifying.Worker>();

--- a/src/melanki.trippeltrumf.service/Features/Notifying/Reminder.cs
+++ b/src/melanki.trippeltrumf.service/Features/Notifying/Reminder.cs
@@ -1,0 +1,52 @@
+namespace melanki.trippeltrumf.service.Features.Notifying;
+
+public static class Reminder
+{
+    public static ReminderEligibility Evaluate(DateOnly? nextTrippelTrumfDate, DateOnly todayInReminderTimeZone, bool alreadySent)
+    {
+        if (nextTrippelTrumfDate is null)
+        {
+            return ReminderEligibility.NoUpcomingDate;
+        }
+
+        if (alreadySent)
+        {
+            return ReminderEligibility.AlreadySent;
+        }
+
+        var reminderDate = nextTrippelTrumfDate.Value.AddDays(-1);
+        return reminderDate == todayInReminderTimeZone
+            ? ReminderEligibility.Eligible
+            : ReminderEligibility.NotDayBefore;
+    }
+}
+
+public enum ReminderEligibility
+{
+    Eligible = 0,
+    NoUpcomingDate = 1,
+    NotDayBefore = 2,
+    AlreadySent = 3
+}
+
+public sealed class ReminderStateStore
+{
+    private readonly object _lock = new();
+    private readonly HashSet<DateOnly> _sentReminderDates = [];
+
+    public bool HasSent(DateOnly eventDate)
+    {
+        lock (_lock)
+        {
+            return _sentReminderDates.Contains(eventDate);
+        }
+    }
+
+    public bool TryMarkSent(DateOnly eventDate)
+    {
+        lock (_lock)
+        {
+            return _sentReminderDates.Add(eventDate);
+        }
+    }
+}

--- a/src/melanki.trippeltrumf.service/Features/Notifying/Worker.cs
+++ b/src/melanki.trippeltrumf.service/Features/Notifying/Worker.cs
@@ -6,21 +6,44 @@ namespace melanki.trippeltrumf.service.Features.Notifying;
 
 public sealed class Worker : BackgroundService
 {
+    private const string OsloTimeZoneId = "Europe/Oslo";
+    private static readonly TimeSpan ReminderCheckInterval = TimeSpan.FromHours(12);
+
     private readonly ChangeFeed _changeFeed;
+    private readonly StateStore _stateStore;
+    private readonly ReminderStateStore _reminderStateStore;
     private readonly Client _client;
     private readonly ILogger<Worker> _logger;
+    private readonly TimeZoneInfo _reminderTimeZone;
 
     public Worker(
         ChangeFeed changeFeed,
+        StateStore stateStore,
+        ReminderStateStore reminderStateStore,
         Client client,
         ILogger<Worker> logger)
     {
         _changeFeed = changeFeed;
+        _stateStore = stateStore;
+        _reminderStateStore = reminderStateStore;
         _client = client;
         _logger = logger;
+        _reminderTimeZone = ResolveTimeZone(logger);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "Notifying worker started. TimeZoneId {TimeZoneId}, ReminderCheckInterval {ReminderCheckInterval}.",
+            _reminderTimeZone.Id,
+            ReminderCheckInterval);
+
+        var changeFeedTask = ProcessStateChangesAsync(stoppingToken);
+        var reminderTask = RunReminderLoopAsync(stoppingToken);
+        await Task.WhenAll(changeFeedTask, reminderTask);
+    }
+
+    private async Task ProcessStateChangesAsync(CancellationToken stoppingToken)
     {
         await foreach (var change in _changeFeed.ReadAllAsync(stoppingToken))
         {
@@ -39,6 +62,90 @@ public sealed class Worker : BackgroundService
             {
                 _logger.LogWarning(exception, "Failed to publish state change to Slack ({Reason}).", change.Reason);
             }
+        }
+    }
+
+    private async Task RunReminderLoopAsync(CancellationToken stoppingToken)
+    {
+        await CheckReminderAsync("startup", stoppingToken);
+
+        using var timer = new PeriodicTimer(ReminderCheckInterval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await CheckReminderAsync("scheduled", stoppingToken);
+        }
+    }
+
+    private async Task CheckReminderAsync(string reason, CancellationToken cancellationToken)
+    {
+        var snapshot = _stateStore.GetSnapshot();
+        var nextDate = snapshot.ParsedNextDate;
+        var todayInReminderTimeZone = GetTodayInReminderTimeZone();
+        if (nextDate is null)
+        {
+            _logger.LogDebug(
+                "Reminder check skipped ({Reason}). No cached next date. TodayInReminderTimeZone {Today}, TimeZoneId {TimeZoneId}",
+                reason,
+                todayInReminderTimeZone,
+                _reminderTimeZone.Id);
+            return;
+        }
+
+        var alreadySent = _reminderStateStore.HasSent(nextDate.Value);
+        var eligibility = Reminder.Evaluate(nextDate, todayInReminderTimeZone, alreadySent);
+        if (eligibility != ReminderEligibility.Eligible)
+        {
+            _logger.LogDebug(
+                "Reminder check not eligible ({Reason}). NextDate {NextDate}, TodayInReminderTimeZone {Today}, Eligibility {Eligibility}, TimeZoneId {TimeZoneId}",
+                reason,
+                nextDate,
+                todayInReminderTimeZone,
+                eligibility,
+                _reminderTimeZone.Id);
+            return;
+        }
+
+        try
+        {
+            await _client.NotifyStateChangeAsync(
+                new StateChange("day-before-reminder", snapshot),
+                cancellationToken);
+            _reminderStateStore.TryMarkSent(nextDate.Value);
+            _logger.LogInformation(
+                "Published day-before reminder for date {NextDate}. TimeZoneId {TimeZoneId}",
+                nextDate,
+                _reminderTimeZone.Id);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Failed to publish day-before reminder for date {NextDate}.",
+                nextDate);
+        }
+    }
+
+    private DateOnly GetTodayInReminderTimeZone()
+    {
+        var nowInReminderTimeZone = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, _reminderTimeZone);
+        return DateOnly.FromDateTime(nowInReminderTimeZone.DateTime);
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(ILogger logger)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(OsloTimeZoneId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            logger.LogWarning("Oslo timezone id {TimeZoneId} was not found. Falling back to UTC.", OsloTimeZoneId);
+            return TimeZoneInfo.Utc;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            logger.LogWarning("Oslo timezone id {TimeZoneId} is invalid. Falling back to UTC.", OsloTimeZoneId);
+            return TimeZoneInfo.Utc;
         }
     }
 }

--- a/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ReminderPolicyTests.cs
+++ b/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ReminderPolicyTests.cs
@@ -1,0 +1,50 @@
+using melanki.trippeltrumf.service.Features.Notifying;
+using Xunit;
+
+namespace melanki.trippeltrumf.service.tests.Features.Notifying;
+
+public sealed class ReminderPolicyTests
+{
+    [Fact]
+    public void Evaluate_ReturnsEligible_OnCalendarDayBefore_WhenNotAlreadySent()
+    {
+        var nextDate = new DateOnly(2026, 12, 10);
+        var today = new DateOnly(2026, 12, 9);
+
+        var result = Reminder.Evaluate(nextDate, today, alreadySent: false);
+
+        Assert.Equal(ReminderEligibility.Eligible, result);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsNoUpcomingDate_WhenDateIsMissing()
+    {
+        var today = new DateOnly(2026, 12, 9);
+
+        var result = Reminder.Evaluate(nextTrippelTrumfDate: null, today, alreadySent: false);
+
+        Assert.Equal(ReminderEligibility.NoUpcomingDate, result);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsNotDayBefore_WhenTodayDoesNotMatchReminderDate()
+    {
+        var nextDate = new DateOnly(2026, 12, 10);
+        var today = new DateOnly(2026, 12, 8);
+
+        var result = Reminder.Evaluate(nextDate, today, alreadySent: false);
+
+        Assert.Equal(ReminderEligibility.NotDayBefore, result);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsAlreadySent_WhenReminderAlreadySentForEventDate()
+    {
+        var nextDate = new DateOnly(2026, 12, 10);
+        var today = new DateOnly(2026, 12, 9);
+
+        var result = Reminder.Evaluate(nextDate, today, alreadySent: true);
+
+        Assert.Equal(ReminderEligibility.AlreadySent, result);
+    }
+}

--- a/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ReminderStateStoreTests.cs
+++ b/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ReminderStateStoreTests.cs
@@ -1,0 +1,31 @@
+using melanki.trippeltrumf.service.Features.Notifying;
+using Xunit;
+
+namespace melanki.trippeltrumf.service.tests.Features.Notifying;
+
+public sealed class ReminderStateStoreTests
+{
+    [Fact]
+    public void TryMarkSent_IsIdempotent_ForSameEventDate()
+    {
+        var store = new ReminderStateStore();
+        var eventDate = new DateOnly(2026, 3, 14);
+
+        var first = store.TryMarkSent(eventDate);
+        var second = store.TryMarkSent(eventDate);
+
+        Assert.True(first);
+        Assert.False(second);
+    }
+
+    [Fact]
+    public void HasSent_ReturnsTrue_AfterMarkingEventDate()
+    {
+        var store = new ReminderStateStore();
+        var eventDate = new DateOnly(2026, 3, 14);
+
+        store.TryMarkSent(eventDate);
+
+        Assert.True(store.HasSent(eventDate));
+    }
+}

--- a/tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj
+++ b/tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/melanki.trippeltrumf.service/melanki.trippeltrumf.service.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add day-before reminder checks to notifying flow
- merge reminder logic and in-memory reminder state into Reminder.cs
- merge reminder scheduling into Features/Notifying/Worker
- add reminder policy/state tests and update solution/docs
- add AGENTS.md note that PR descriptions should include issue resolution references

## Validation
- dotnet test melanki.trippeltrumf.sln -v minimal

Resolves #1