### PR TITLE
feat: add release-driven CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/packages.lock.json
+
+      - name: Restore
+        run: dotnet restore melanki.trippeltrumf.sln
+
+      - name: Build
+        run: dotnet build src/melanki.trippeltrumf.service/melanki.trippeltrumf.service.csproj -c Release --no-restore
+
+      - name: Test
+        run: dotnet test tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj -c Release --no-restore --verbosity normal

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,82 @@
+name: Container
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Normalize image name
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "${GITHUB_OUTPUT}"
+
+      - name: Compute version
+        id: version
+        run: |
+          set -euo pipefail
+          commit_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=7 "${commit_sha}")"
+          value="sha-${short_sha}"
+
+          echo "value=${value}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=${short_sha}" >> "${GITHUB_OUTPUT}"
+          echo "commit_sha=${commit_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ steps.version.outputs.value }}
+            ${{ steps.image.outputs.name }}:main
+
+      - name: Image summary
+        run: |
+          echo "Published image tags:"
+          echo "${{ steps.image.outputs.name }}:${{ steps.version.outputs.value }}"
+          echo "${{ steps.image.outputs.name }}:main"
+
+      - name: Create GitHub release
+        if: github.event_name == 'workflow_run'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.value }}
+          name: Release ${{ steps.version.outputs.value }}
+          target_commitish: ${{ steps.version.outputs.commit_sha }}
+          generate_release_notes: true
+          make_latest: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,106 @@
+name: Deploy
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Optional image tag to deploy (for example sha-a1b2c3d). Defaults to main for manual runs.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-trippel-trumf
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${KUBECONFIG_B64}" ]]; then
+            echo "KUBECONFIG_B64 secret is required"
+            exit 1
+          fi
+
+          mkdir -p "${HOME}/.kube"
+          echo "${KUBECONFIG_B64}" | base64 --decode > "${HOME}/.kube/config"
+          chmod 600 "${HOME}/.kube/config"
+
+      - name: Determine image reference
+        id: image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_IMAGE_TAG: ${{ github.event.inputs.image_tag || '' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          image_repository="ghcr.io/${REPOSITORY,,}"
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_IMAGE_TAG}" ]]; then
+            image_tag="${INPUT_IMAGE_TAG}"
+          elif [[ "${EVENT_NAME}" == "release" && -n "${RELEASE_TAG}" ]]; then
+            image_tag="${RELEASE_TAG}"
+          else
+            image_tag="main"
+          fi
+
+          image_ref="${image_repository}:${image_tag}"
+
+          echo "tag=${image_tag}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${image_ref}" >> "${GITHUB_OUTPUT}"
+          echo "Deploying image ${image_ref}"
+
+      - name: Apply namespace
+        run: kubectl apply -f deploy/k8s/namespace.yaml
+
+      - name: Create or update Slack webhook secret
+        env:
+          SLACK_WORKFLOW_WEBHOOK_URL: ${{ secrets.TrippelTrumfService__SlackWorkflowWebhookUrl }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SLACK_WORKFLOW_WEBHOOK_URL}" ]]; then
+            echo "TrippelTrumfService__SlackWorkflowWebhookUrl secret is required"
+            exit 1
+          fi
+
+          temp_file="$(mktemp)"
+          trap 'rm -f "${temp_file}"' EXIT
+          printf '%s' "${SLACK_WORKFLOW_WEBHOOK_URL}" > "${temp_file}"
+
+          kubectl -n trippel-trumf create secret generic trippel-trumf-worker-secrets \
+            --from-file=TrippelTrumfService__SlackWorkflowWebhookUrl="${temp_file}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Apply manifests
+        run: kubectl apply -k deploy/k8s
+
+      - name: Set deployment image
+        run: |
+          kubectl -n trippel-trumf set image deployment/trippel-trumf-worker \
+            worker=${{ steps.image.outputs.ref }}
+
+      - name: Verify rollout
+        run: |
+          kubectl -n trippel-trumf rollout status deployment/trippel-trumf-worker --timeout=300s
+          kubectl -n trippel-trumf get deployment trippel-trumf-worker -o wide

--- a/README.md
+++ b/README.md
@@ -117,6 +117,46 @@ docker build -t ghcr.io/<owner>/trippel-trumf-slack-workflow-worker:<tag> .
 
 The image uses a multi-stage `Dockerfile` and runs the published worker inside the official Playwright .NET container so browser dependencies are present at runtime.
 
+## GitHub Actions CI/CD
+
+This repository uses commit-sha release versioning and a three-workflow CI/CD chain.
+
+Version format:
+
+- `sha-<shortsha>` (example: `sha-a1b2c3d`)
+- `<shortsha>` is the 7-character commit hash from the merge commit on `main`
+
+Release and deployment flow:
+
+1. Changes are merged to `main`.
+2. `CI` validates restore/build/tests.
+3. `Container` builds and pushes image tags:
+   - `sha-<shortsha>` (immutable release tag)
+   - `main`
+4. `Container` creates a GitHub Release with tag `sha-<shortsha>`.
+5. `Deploy` is triggered by `release.published` and deploys image `ghcr.io/<owner>/<repo>:sha-<shortsha>` to k3s.
+
+Workflow summary:
+
+- `CI` (`.github/workflows/ci.yml`)
+  - Trigger: pull requests and pushes to `main`
+  - Runs `dotnet restore`, release build for the worker project, and test execution
+- `Container` (`.github/workflows/container.yml`)
+  - Trigger: successful `CI` workflow run on `main`, and manual dispatch
+  - Builds and pushes release-tagged image + creates GitHub Release on CI-validated `main` merges
+- `Deploy` (`.github/workflows/deploy.yml`)
+  - Trigger: published release, or manual dispatch
+  - Applies manifests, updates deployment image, and verifies rollout with `kubectl rollout status`
+
+Required GitHub Secrets for deployment:
+
+- `KUBECONFIG_B64`
+  - Base64-encoded kubeconfig used by the deploy workflow
+- `TrippelTrumfService__SlackWorkflowWebhookUrl`
+  - Injected by the deploy workflow into Kubernetes secret `trippel-trumf-worker-secrets` (key `TrippelTrumfService__SlackWorkflowWebhookUrl`)
+
+The Slack webhook value is never stored in git-tracked manifests or `appsettings` files.
+
 ## k3s deployment
 
 Kubernetes manifests are under `deploy/k8s/`.
@@ -135,7 +175,7 @@ kubectl -n trippel-trumf create secret generic trippel-trumf-worker-secrets \
   --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -k deploy/k8s
 kubectl -n trippel-trumf set image deployment/trippel-trumf-worker \
-  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<commit-sha>
+  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<sha-a1b2c3d>
 kubectl -n trippel-trumf rollout status deployment/trippel-trumf-worker --timeout=300s
 ```
 

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -14,7 +14,9 @@ This folder contains a production-oriented base deployment for `melanki.trippelt
 
 `TrippelTrumfService:SlackWorkflowWebhookUrl` must come from a Kubernetes secret.
 
-Create/update it before applying the deployment:
+GitHub Actions deployment (`.github/workflows/deploy.yml`) creates or updates this automatically from GitHub Secret `TrippelTrumfService__SlackWorkflowWebhookUrl`.
+
+For manual/local deployment, create/update it before applying the deployment:
 
 ```bash
 kubectl -n trippel-trumf create secret generic trippel-trumf-worker-secrets \
@@ -41,9 +43,11 @@ To deploy a specific immutable image tag (recommended):
 
 ```bash
 kubectl -n trippel-trumf set image deployment/trippel-trumf-worker \
-  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<commit-sha>
+  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<sha-a1b2c3d>
 kubectl -n trippel-trumf rollout status deployment/trippel-trumf-worker --timeout=300s
 ```
+
+The GitHub Actions deploy workflow performs the same image update and rollout verification automatically when a GitHub Release is published.
 
 ## Validate
 
@@ -66,6 +70,6 @@ Rollback to a known previous image tag:
 
 ```bash
 kubectl -n trippel-trumf set image deployment/trippel-trumf-worker \
-  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<previous-commit-sha>
+  worker=ghcr.io/melanki/trippel-trumf-slack-workflow-worker:<previous-sha-a1b2c3d>
 kubectl -n trippel-trumf rollout status deployment/trippel-trumf-worker --timeout=300s
 ```


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow for restore/build/test on PRs and `main`
- add container workflow that runs after successful CI on `main`, builds/pushes GHCR images, and creates a GitHub Release tagged `sha-<shortsha>`
- add deploy workflow triggered by `release.published` (or manual dispatch) that updates k3s manifests, injects Slack webhook secret, sets image tag, and verifies rollout
- document versioning/release/deployment strategy and required secrets in README and deploy docs

## Validation
- parsed workflow YAML files locally
- ran `dotnet test tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj -v minimal`

Resolves #2
