### PR TITLE
fix: harden production scrape and Slack webhook diagnostics

### DIFF
--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -7,4 +7,4 @@ metadata:
     app.kubernetes.io/name: trippel-trumf-worker
 data:
   DOTNET_ENVIRONMENT: Production
-  Serilog__MinimumLevel__Default: Information
+  Serilog__MinimumLevel__Default: Debug

--- a/src/melanki.trippeltrumf.service/Features/Notifying/Client.cs
+++ b/src/melanki.trippeltrumf.service/Features/Notifying/Client.cs
@@ -1,4 +1,7 @@
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Diagnostics;
 using melanki.trippeltrumf.service.Features.Polling;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,41 +24,110 @@ public sealed class Client
         _logger = logger;
     }
 
-    public async Task NotifyStateChangeAsync(StateChange change, CancellationToken cancellationToken)
+    public async Task<bool> NotifyStateChangeAsync(StateChange change, CancellationToken cancellationToken)
     {
         var webhookUrl = _options.Value.SlackWorkflowWebhookUrl;
         if (string.IsNullOrWhiteSpace(webhookUrl))
         {
             _logger.LogDebug("Slack notification skipped: TrippelTrumfService:SlackWorkflowWebhookUrl is not configured.");
-            return;
+            return false;
+        }
+
+        var nextDate = BuildDate(change);
+        if (string.IsNullOrWhiteSpace(nextDate))
+        {
+            _logger.LogWarning(
+                "Slack notification skipped ({Reason}): next Trippel-Trumf date is missing. LastError {LastError}",
+                change.Reason,
+                change.Snapshot.LastError);
+            return false;
         }
 
         var payload = new
         {
-            trippel_trumf_date = BuildDate(change)
+            trippel_trumf_date = nextDate
         };
+        var endpoint = DescribeWebhookEndpoint(webhookUrl);
+        var requestDuration = Stopwatch.StartNew();
         _logger.LogDebug(
-            "Posting Slack notification. Reason {Reason}, NextTrippelTrumfDate {NextDate}",
+            "Sending Slack webhook POST. Reason {Reason}, NextTrippelTrumfDate {NextDate}, WebhookHost {WebhookHost}, WebhookPathHash {WebhookPathHash}",
             change.Reason,
-            payload.trippel_trumf_date);
+            payload.trippel_trumf_date,
+            endpoint.Host,
+            endpoint.PathHash);
 
-        using var response = await _httpClient.PostAsJsonAsync(webhookUrl, payload, cancellationToken);
-        if (!response.IsSuccessStatusCode)
+        try
         {
+            using var response = await _httpClient.PostAsJsonAsync(webhookUrl, payload, cancellationToken);
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            throw new InvalidOperationException(
-                $"Slack webhook returned {(int)response.StatusCode}: {body}");
-        }
+            requestDuration.Stop();
 
-        _logger.LogDebug(
-            "Slack notification succeeded. StatusCode {StatusCode}, Reason {Reason}",
-            (int)response.StatusCode,
-            change.Reason);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responsePreview = Truncate(body, 512);
+                _logger.LogWarning(
+                    "Slack webhook POST failed. Reason {Reason}, StatusCode {StatusCode}, DurationMs {DurationMs}, WebhookHost {WebhookHost}, WebhookPathHash {WebhookPathHash}, ResponseBodyPreview {ResponseBodyPreview}",
+                    change.Reason,
+                    (int)response.StatusCode,
+                    requestDuration.ElapsedMilliseconds,
+                    endpoint.Host,
+                    endpoint.PathHash,
+                    responsePreview);
+
+                throw new InvalidOperationException(
+                    $"Slack webhook returned {(int)response.StatusCode}: {responsePreview}");
+            }
+
+            _logger.LogInformation(
+                "Slack webhook POST succeeded. Reason {Reason}, StatusCode {StatusCode}, DurationMs {DurationMs}, WebhookHost {WebhookHost}, WebhookPathHash {WebhookPathHash}",
+                change.Reason,
+                (int)response.StatusCode,
+                requestDuration.ElapsedMilliseconds,
+                endpoint.Host,
+                endpoint.PathHash);
+            return true;
+        }
+        catch (HttpRequestException exception)
+        {
+            requestDuration.Stop();
+            _logger.LogWarning(
+                exception,
+                "Slack webhook POST request error. Reason {Reason}, DurationMs {DurationMs}, WebhookHost {WebhookHost}, WebhookPathHash {WebhookPathHash}",
+                change.Reason,
+                requestDuration.ElapsedMilliseconds,
+                endpoint.Host,
+                endpoint.PathHash);
+            throw;
+        }
     }
 
     private static string BuildDate(StateChange change)
     {
         var snapshot = change.Snapshot;
         return snapshot.Result?.NextTrippelTrumfDate ?? string.Empty;
+    }
+
+    private static (string Host, string PathHash) DescribeWebhookEndpoint(string webhookUrl)
+    {
+        if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out var uri))
+        {
+            return ("invalid", "invalid");
+        }
+
+        var path = uri.AbsolutePath;
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(path));
+        var hash = Convert.ToHexString(hashBytes.AsSpan(0, 8));
+
+        return (uri.Host, hash);
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        return value[..maxLength];
     }
 }

--- a/src/melanki.trippeltrumf.service/Features/Notifying/Worker.cs
+++ b/src/melanki.trippeltrumf.service/Features/Notifying/Worker.cs
@@ -55,8 +55,15 @@ public sealed class Worker : BackgroundService
 
             try
             {
-                await _client.NotifyStateChangeAsync(change, stoppingToken);
-                _logger.LogInformation("Published state change to Slack ({Reason}).", change.Reason);
+                var sent = await _client.NotifyStateChangeAsync(change, stoppingToken);
+                if (sent)
+                {
+                    _logger.LogInformation("Published state change to Slack ({Reason}).", change.Reason);
+                }
+                else
+                {
+                    _logger.LogDebug("State change was not sent to Slack ({Reason}).", change.Reason);
+                }
             }
             catch (Exception exception)
             {
@@ -107,14 +114,24 @@ public sealed class Worker : BackgroundService
 
         try
         {
-            await _client.NotifyStateChangeAsync(
+            var sent = await _client.NotifyStateChangeAsync(
                 new StateChange("day-before-reminder", snapshot),
                 cancellationToken);
-            _reminderStateStore.TryMarkSent(nextDate.Value);
-            _logger.LogInformation(
-                "Published day-before reminder for date {NextDate}. TimeZoneId {TimeZoneId}",
-                nextDate,
-                _reminderTimeZone.Id);
+            if (sent)
+            {
+                _reminderStateStore.TryMarkSent(nextDate.Value);
+                _logger.LogInformation(
+                    "Published day-before reminder for date {NextDate}. TimeZoneId {TimeZoneId}",
+                    nextDate,
+                    _reminderTimeZone.Id);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Day-before reminder was not sent for date {NextDate}. TimeZoneId {TimeZoneId}",
+                    nextDate,
+                    _reminderTimeZone.Id);
+            }
         }
         catch (Exception exception)
         {

--- a/src/melanki.trippeltrumf.service/Features/Polling/DateExtractor.cs
+++ b/src/melanki.trippeltrumf.service/Features/Polling/DateExtractor.cs
@@ -5,7 +5,7 @@ namespace melanki.trippeltrumf.service.Features.Polling;
 public static class DateExtractor
 {
     private static readonly Regex DatePattern = new(
-        @"\b(?<day>[1-9]|[12]\d|3[01])\.\s*(?<month>januar|februar|mars|april|mai|juni|juli|august|september|oktober|november|desember)\b",
+        @"\b(?<day>[1-9]|[12]\d|3[01])\s*\.?\s*(?<month>januar|februar|mars|april|mai|juni|juli|august|september|oktober|november|desember)\b",
         RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Dictionary<string, int> NorwegianMonths = new(StringComparer.OrdinalIgnoreCase)

--- a/src/melanki.trippeltrumf.service/Features/Scraping/Scraper.cs
+++ b/src/melanki.trippeltrumf.service/Features/Scraping/Scraper.cs
@@ -8,6 +8,9 @@ namespace melanki.trippeltrumf.service.Features.Scraping;
 public class Scraper
 {
     private const string TrippelTrumfPageUrl = "https://www.trumf.no/trippel-trumf";
+    private const string PreferredContentSelector = "article";
+    private const string FallbackMainSelector = "main#maincontent";
+    private static readonly TimeSpan ContentWaitTimeout = TimeSpan.FromSeconds(15);
     private readonly ILogger<Scraper> _logger;
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -33,10 +36,17 @@ public class Scraper
                 @"() => {
                     const title = document.title || '';
                     const article = document.querySelector('article');
+                    const mainContent = document.querySelector('main#maincontent') ?? document.querySelector('main[role=""main""]');
+                    const contentRoot = article ?? mainContent ?? document.body;
                     const canonicalUrl = document.querySelector('link[rel=""canonical""]')?.href ?? null;
                     const description = document.querySelector('meta[name=""description""]')?.content ?? null;
-                    const articleHtml = article ? article.innerHTML : '';
-                    const paragraphNodes = article ? article.querySelectorAll('p') : [];
+                    const articleHtml = contentRoot ? contentRoot.innerHTML : '';
+                    const paragraphNodes = contentRoot ? contentRoot.querySelectorAll('p') : [];
+                    const contentSource = article
+                        ? 'article'
+                        : mainContent
+                            ? 'main'
+                            : 'body';
 
                     const paragraphs = Array.from(paragraphNodes)
                         .map((node) => (node.textContent || '').replace(/\s+/g, ' ').trim())
@@ -48,7 +58,8 @@ public class Scraper
                         canonicalUrl,
                         description,
                         articleHtml,
-                        paragraphs
+                        paragraphs,
+                        contentSource
                     });
                 }"),
             cancellationToken);
@@ -56,9 +67,10 @@ public class Scraper
         var snapshot = JsonSerializer.Deserialize<PageSnapshot>(snapshotJson, JsonOptions)
             ?? throw new InvalidOperationException("Failed to deserialize structured page snapshot.");
         _logger.LogDebug(
-            "Structured page scraped. Url {Url}, Title {Title}, ParagraphCount {ParagraphCount}, ArticleHtmlLength {ArticleHtmlLength}",
+            "Structured page scraped. Url {Url}, Title {Title}, ContentSource {ContentSource}, ParagraphCount {ParagraphCount}, ArticleHtmlLength {ArticleHtmlLength}",
             snapshot.Url,
             snapshot.Title,
+            snapshot.ContentSource,
             snapshot.Paragraphs.Count,
             snapshot.ArticleHtml.Length);
 
@@ -78,11 +90,10 @@ public class Scraper
             page => page.EvaluateAsync<string>(
                 @"() => {
                     const article = document.querySelector('article');
-                    if (!article) {
-                        return '';
-                    }
+                    const mainContent = document.querySelector('main#maincontent') ?? document.querySelector('main[role=""main""]');
+                    const contentRoot = article ?? mainContent ?? document.body;
 
-                    return (article.innerText || article.textContent || '')
+                    return (contentRoot?.innerText || contentRoot?.textContent || '')
                         .replace(/\s+/g, ' ')
                         .trim();
                 }"),
@@ -95,9 +106,16 @@ public class Scraper
             page => page.EvaluateAsync<string>(
                 @"() => {
                     const article = document.querySelector('article');
-                    const articleText = article
-                        ? (article.innerText || article.textContent || '').replace(/\s+/g, ' ').trim()
-                        : '';
+                    const mainContent = document.querySelector('main#maincontent') ?? document.querySelector('main[role=""main""]');
+                    const contentRoot = article ?? mainContent ?? document.body;
+                    const contentSource = article
+                        ? 'article'
+                        : mainContent
+                            ? 'main'
+                            : 'body';
+                    const articleText = (contentRoot?.innerText || contentRoot?.textContent || '')
+                        .replace(/\s+/g, ' ')
+                        .trim();
 
                     const findDateModified = (value) => {
                         if (!value || typeof value !== 'object') {
@@ -150,7 +168,8 @@ public class Scraper
 
                     return JSON.stringify({
                         articleText,
-                        dateModified
+                        dateModified,
+                        contentSource
                     });
                 }"),
             cancellationToken);
@@ -159,8 +178,16 @@ public class Scraper
             ?? throw new InvalidOperationException("Failed to deserialize rendered article snapshot.");
 
         var dateModifiedParts = ParseDateParts(snapshot.DateModified);
+        if (!string.Equals(snapshot.ContentSource, "article", StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Preferred article element was missing during scrape. Using {ContentSource} fallback.",
+                snapshot.ContentSource);
+        }
+
         _logger.LogDebug(
-            "Rendered article scraped. ArticleTextLength {ArticleTextLength}, DateModifiedRaw {DateModifiedRaw}, DateModifiedYear {DateModifiedYear}, DateModifiedMonth {DateModifiedMonth}",
+            "Rendered article scraped. ContentSource {ContentSource}, ArticleTextLength {ArticleTextLength}, DateModifiedRaw {DateModifiedRaw}, DateModifiedYear {DateModifiedYear}, DateModifiedMonth {DateModifiedMonth}",
+            snapshot.ContentSource,
             snapshot.ArticleText.Length,
             snapshot.DateModified,
             dateModifiedParts.Year,
@@ -184,6 +211,7 @@ public class Scraper
         {
             WaitUntil = WaitUntilState.NetworkIdle
         });
+        await WaitForContentAsync(page, cancellationToken);
 
         cancellationToken.ThrowIfCancellationRequested();
         return await action(page);
@@ -216,12 +244,14 @@ public class Scraper
         public string? Description { get; init; }
         public string ArticleHtml { get; init; } = string.Empty;
         public IReadOnlyList<string> Paragraphs { get; init; } = [];
+        public string ContentSource { get; init; } = "unknown";
     }
 
     private sealed class RenderedArticleSnapshotDto
     {
         public string ArticleText { get; init; } = string.Empty;
         public string? DateModified { get; init; }
+        public string ContentSource { get; init; } = "unknown";
     }
 
     private static (int? Year, int? Month) ParseDateParts(string? value)
@@ -241,5 +271,38 @@ public class Scraper
         }
 
         return (null, null);
+    }
+
+    private static async Task WaitForContentAsync(IPage page, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            await page.WaitForSelectorAsync(
+                PreferredContentSelector,
+                new PageWaitForSelectorOptions
+                {
+                    State = WaitForSelectorState.Attached,
+                    Timeout = (float)ContentWaitTimeout.TotalMilliseconds
+                });
+            return;
+        }
+        catch (TimeoutException)
+        {
+            // The page can be rendered without an article element; fallback selectors are handled below.
+        }
+        catch (PlaywrightException)
+        {
+            // Continue to fallback selectors.
+        }
+
+        await page.WaitForSelectorAsync(
+            FallbackMainSelector,
+            new PageWaitForSelectorOptions
+            {
+                State = WaitForSelectorState.Attached,
+                Timeout = (float)ContentWaitTimeout.TotalMilliseconds
+            });
     }
 }

--- a/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ClientTests.cs
+++ b/tests/melanki.trippeltrumf.service.tests/Features/Notifying/ClientTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Text.Json;
+using melanki.trippeltrumf.service.Features.Polling;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace melanki.trippeltrumf.service.tests.Features.Notifying;
+
+public sealed class ClientTests
+{
+    [Fact]
+    public async Task NotifyStateChangeAsync_SkipsWebhookCall_WhenDateIsMissing()
+    {
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new melanki.trippeltrumf.service.Features.Notifying.Options
+        {
+            SlackWorkflowWebhookUrl = "https://example.invalid/webhook"
+        });
+        var client = new melanki.trippeltrumf.service.Features.Notifying.Client(
+            httpClient,
+            options,
+            NullLogger<melanki.trippeltrumf.service.Features.Notifying.Client>.Instance);
+
+        var change = new StateChange(
+            Reason: "startup",
+            Snapshot: new StateSnapshot(
+                Result: new Result(null),
+                ParsedNextDate: null,
+                CachedAtUtc: null,
+                LastAttemptAtUtc: DateTimeOffset.UtcNow,
+                LastError: "scrape failed",
+                ReferenceYear: null,
+                ReferenceMonth: null));
+
+        var sent = await client.NotifyStateChangeAsync(change, CancellationToken.None);
+
+        Assert.False(sent);
+        Assert.Equal(0, handler.CallCount);
+    }
+
+    [Fact]
+    public async Task NotifyStateChangeAsync_PostsWebhookPayload_WhenDateExists()
+    {
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new melanki.trippeltrumf.service.Features.Notifying.Options
+        {
+            SlackWorkflowWebhookUrl = "https://example.invalid/webhook"
+        });
+        var client = new melanki.trippeltrumf.service.Features.Notifying.Client(
+            httpClient,
+            options,
+            NullLogger<melanki.trippeltrumf.service.Features.Notifying.Client>.Instance);
+
+        var change = new StateChange(
+            Reason: "startup",
+            Snapshot: new StateSnapshot(
+                Result: new Result("2026-03-26"),
+                ParsedNextDate: new DateOnly(2026, 3, 26),
+                CachedAtUtc: DateTimeOffset.UtcNow,
+                LastAttemptAtUtc: DateTimeOffset.UtcNow,
+                LastError: null,
+                ReferenceYear: 2026,
+                ReferenceMonth: 3));
+
+        var sent = await client.NotifyStateChangeAsync(change, CancellationToken.None);
+
+        Assert.True(sent);
+        Assert.Equal(1, handler.CallCount);
+        Assert.NotNull(handler.RequestBody);
+
+        using var payload = JsonDocument.Parse(handler.RequestBody!);
+        Assert.Equal(
+            "2026-03-26",
+            payload.RootElement.GetProperty("trippel_trumf_date").GetString());
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        public string? RequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            RequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+}

--- a/tests/melanki.trippeltrumf.service.tests/Features/Polling/DateExtractorTests.cs
+++ b/tests/melanki.trippeltrumf.service.tests/Features/Polling/DateExtractorTests.cs
@@ -1,0 +1,40 @@
+using melanki.trippeltrumf.service.Features.Polling;
+using Xunit;
+
+namespace melanki.trippeltrumf.service.tests.Features.Polling;
+
+public sealed class DateExtractorTests
+{
+    [Fact]
+    public void ExtractNext_ReturnsDate_WhenTextContainsDotSeparatedDayAndMonth()
+    {
+        var articleText = "Neste Trippel-Trumf er torsdag 26. mars.";
+        var todayUtc = new DateOnly(2026, 3, 20);
+
+        var result = DateExtractor.ExtractNext(articleText, todayUtc, referenceYear: 2026, referenceMonth: 3);
+
+        Assert.Equal("2026-03-26", result.NextTrippelTrumfDate);
+    }
+
+    [Fact]
+    public void ExtractNext_ReturnsDate_WhenTextContainsSpaceSeparatedDayAndMonth()
+    {
+        var articleText = "Neste Trippel-Trumf er torsdag 26 mars.";
+        var todayUtc = new DateOnly(2026, 3, 20);
+
+        var result = DateExtractor.ExtractNext(articleText, todayUtc, referenceYear: 2026, referenceMonth: 3);
+
+        Assert.Equal("2026-03-26", result.NextTrippelTrumfDate);
+    }
+
+    [Fact]
+    public void ExtractNext_RollsYear_WhenReferenceMonthIsDecemberAndExtractedMonthIsJanuary()
+    {
+        var articleText = "Neste Trippel-Trumf er torsdag 8. januar.";
+        var todayUtc = new DateOnly(2025, 12, 10);
+
+        var result = DateExtractor.ExtractNext(articleText, todayUtc, referenceYear: 2025, referenceMonth: 12);
+
+        Assert.Equal("2026-01-08", result.NextTrippelTrumfDate);
+    }
+}


### PR DESCRIPTION
## Summary
- harden Playwright scraping by waiting for content and falling back from article to main#maincontent/body when needed
- broaden date parsing to accept both "26. mars" and "26 mars"
- skip Slack webhook posts when date is missing, and align worker logs with actual send/skip behavior
- add explicit Slack webhook POST diagnostics (status, duration, safe endpoint fingerprint, response preview on errors)
- set production Kubernetes log level to Debug via configmap
- add tests for date extraction variants/year rollover and notifier send/skip behavior

## Validation
- dotnet test tests/melanki.trippeltrumf.service.tests/melanki.trippeltrumf.service.tests.csproj -v minimal
- Passed: 11, Failed: 0
